### PR TITLE
removed cursed shit and made it work

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -3,6 +3,4 @@ PREFIX = /usr/local
 ICONS = 1
 CFLAGS += -Iinclude -Wall -Wextra -pedantic -DICONS=${ICONS}
 
-NCURSES = ncurses`pkg-config --exists ncursesw && echo w`
-TINFO = `[ "$$(uname)" = Darwin ] && echo -ltinfo`
-LDFLAGS = -l${NCURSES} ${TINFO}
+LDFLAGS = `pkg-config --libs-only-l ncurses`

--- a/config.mk
+++ b/config.mk
@@ -3,4 +3,4 @@ PREFIX = /usr/local
 ICONS = 1
 CFLAGS += -Iinclude -Wall -Wextra -pedantic -DICONS=${ICONS}
 
-LDFLAGS = `pkg-config --exists ncursesw && pkg-config --libs ncursesw || pkg-config --libs ncurses`
+LDFLAGS = `pkg-config --libs ncursesw || pkg-config --libs ncurses`

--- a/config.mk
+++ b/config.mk
@@ -3,4 +3,4 @@ PREFIX = /usr/local
 ICONS = 1
 CFLAGS += -Iinclude -Wall -Wextra -pedantic -DICONS=${ICONS}
 
-LDFLAGS = `pkg-config --libs-only-l ncurses`
+LDFLAGS = `pkg-config --libs-only-l ncursesw`

--- a/config.mk
+++ b/config.mk
@@ -3,4 +3,4 @@ PREFIX = /usr/local
 ICONS = 1
 CFLAGS += -Iinclude -Wall -Wextra -pedantic -DICONS=${ICONS}
 
-LDFLAGS = `pkg-config --libs-only-l ncursesw`
+LDFLAGS = `pkg-config --exists ncursesw && pkg-config --libs ncursesw || pkg-config --libs ncurses`


### PR DESCRIPTION
now it *actually* compiles on macos and linux, plus you don't need the extra check for `tinfo` anymore because `pkg-config --libs-only-l` adds that if it's there